### PR TITLE
feat: 自己紹介セクションを追加

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,31 +1,37 @@
 import Link from 'next/link';
 import { FaGithub } from 'react-icons/fa';
-import styles from './page.module.css'; // 作成したCSSファイルをインポート
+import styles from './page.module.css';
+import AboutMe from '@/components/AboutMe'; // ← この行を追加
 
 const HomePage = () => {
   return (
-    <div className={styles.heroSection}>
-      <h1 className={styles.title}>
-        [あなたのキャッチフレーズ]
-      </h1>
-      <p className={styles.name}>
-        [あなたの名前]
-      </p>
-      <p className={styles.description}>
-        ここにあなたの簡単な自己紹介文を入れます。フロントエンド開発への情熱や、
-        どのような技術に興味があるかなどを簡潔に書きましょう。
-      </p>
-
-      <div className={styles.iconLink}>
-        <Link 
-          href="https://github.com/YOUR_USERNAME"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <FaGithub size={40} />
-        </Link>
+    <> {/*複数の要素を並べるため、フラグメント <> で囲みます*/}
+      <div className={styles.heroSection}>
+        {/* ... (ヒーローセクションの中身は変更なし) ... */}
+        <h1 className={styles.title}>
+          [あなたのキャッチフレーズ]
+        </h1>
+        <p className={styles.name}>
+          [あなたの名前]
+        </p>
+        <p className={styles.description}>
+          ここにあなたの簡単な自己紹介文を入れます。フロントエンド開発への情熱や、
+          どのような技術に興味があるかなどを簡潔に書きましょう。
+        </p>
+        <div className={styles.iconLink}>
+          <Link 
+            href="https://github.com/YOUR_USERNAME"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <FaGithub size={40} />
+          </Link>
+        </div>
       </div>
-    </div>
+      
+      <AboutMe /> {/* ← この行を追加 */}
+
+    </>
   );
 };
 

--- a/src/components/AboutMe.module.css
+++ b/src/components/AboutMe.module.css
@@ -1,0 +1,100 @@
+.section {
+  padding: 4rem 1rem; /* 上下の余白を多めに取る */
+}
+
+.container {
+  max-width: 1024px; /* コンテンツの最大幅 */
+  margin: 0 auto; /* 中央揃え */
+  display: flex;
+  align-items: center;
+  gap: 3rem; /* 左右の要素の間隔 */
+}
+
+.imageWrapper {
+  flex-shrink: 0; /* 画像が縮まないようにする */
+}
+
+.imagePlaceholder {
+  width: 200px;
+  height: 200px;
+  background-color: #374151; /* gray-700 */
+  border-radius: 50%; /* 円形にする */
+  border: 4px solid #4b5563; /* gray-600 */
+}
+
+.textWrapper {
+  flex-grow: 1; /* 残りのスペースをすべて使う */
+}
+
+.heading {
+  font-size: 2.25rem; /* 36px */
+  font-weight: 700;
+  margin-bottom: 1.5rem;
+  position: relative;
+  padding-bottom: 0.5rem;
+}
+/* 見出しの下線のデザイン */
+.heading::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 50px;
+  height: 4px;
+  background-color: #a78bfa; /* violet-400 */
+}
+
+.bio {
+  font-size: 1.125rem; /* 18px */
+  line-height: 1.75; /* 行間 */
+  color: #d1d5db; /* gray-300 */
+}
+
+.subHeading {
+  font-size: 1.5rem; /* 24px */
+  font-weight: 600;
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+}
+
+.skillsList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem; /* スキル間の余白 */
+  padding: 0;
+  list-style: none;
+}
+
+.skillItem {
+  background-color: #374151; /* gray-700 */
+  padding: 0.5rem 1rem;
+  border-radius: 9999px; /* 角を丸くしてカプセル状にする */
+  font-size: 0.875rem; /* 14px */
+  font-weight: 500;
+}
+
+/* 画面が狭い場合（スマホなど）のスタイル */
+@media (max-width: 768px) {
+  .container {
+    flex-direction: column; /* 縦並びにする */
+    gap: 2rem;
+  }
+
+  .imagePlaceholder {
+    width: 150px;
+    height: 150px;
+  }
+
+  .textWrapper {
+    text-align: center;
+  }
+
+  .heading::after {
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  .skillsList {
+    justify-content: center;
+  }
+}

--- a/src/components/AboutMe.tsx
+++ b/src/components/AboutMe.tsx
@@ -1,0 +1,38 @@
+import styles from './AboutMe.module.css';
+
+const AboutMe = () => {
+  const skills = ["HTML", "CSS", "JavaScript", "TypeScript", "React", "Next.js", "Git"];
+
+  return (
+    <section className={styles.section}>
+      <div className={styles.container}>
+        {/* 左側：プロフィール画像エリア */}
+        <div className={styles.imageWrapper}>
+          <div className={styles.imagePlaceholder}>
+            {/* 今は画像がないので、枠だけ表示します。後でここにNext.jsのImageコンポーネントを入れます */}
+          </div>
+        </div>
+
+        {/* 右側：テキストエリア */}
+        <div className={styles.textWrapper}>
+          <h2 className={styles.heading}>About Me</h2>
+          <p className={styles.bio}>
+            ここにあなたの自己紹介文を入れます。これまでの学習経験や、
+            どのようなエンジニアになりたいか、あなたの強みなどをアピールしましょう。
+            文章は後でいつでも修正できます。
+          </p>
+          <h3 className={styles.subHeading}>Skills</h3>
+          <ul className={styles.skillsList}>
+            {skills.map((skill) => (
+              <li key={skill} className={styles.skillItem}>
+                {skill}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default AboutMe;


### PR DESCRIPTION
## 概要
トップページに、プロフィール画像、自己紹介文、スキル一覧を含む自己紹介セクションを追加しました。

## 変更内容
- `AboutMe.tsx` と `AboutMe.module.css` を新規作成
- レスポンシブ対応のレイアウトを実装
- `page.tsx` に作成したコンポーネントを統合

## 関連Issue
Closes #1