### PR TITLE
feat: ページ内ナビゲーションにスムーズスクロールを実装

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,6 +9,10 @@ body,
   padding: 0;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   color: white;
   background-color: #0d1117;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,9 @@ import Works from '@/components/Works';
 const HomePage = () => {
   return (
     <> {/*複数の要素を並べるため、フラグメント <> で囲みます*/}
-      <div className={styles.heroSection}>
+      
+      {/* ↓↓↓ このdivに id="home" を追加します ↓↓↓ */}
+      <div id="home" className={styles.heroSection}>
         {/* ... (ヒーローセクションの中身は変更なし) ... */}
         <h1 className={styles.title}>
           [あなたのキャッチフレーズ]

--- a/src/components/AboutMe.tsx
+++ b/src/components/AboutMe.tsx
@@ -1,19 +1,19 @@
-"use client"; // Framer Motionを使うコンポーネントにも必要です
+"use client";
 
-import { motion } from 'framer-motion'; // ← motionをインポート
+import { motion } from 'framer-motion';
 import styles from './AboutMe.module.css';
 
 const AboutMe = () => {
   const skills = ["HTML", "CSS", "JavaScript", "TypeScript", "React", "Next.js", "Git"];
 
   return (
-    // <section> を <motion.section> に変更し、アニメーションの指示を追加
     <motion.section 
+      id="about" // ← この行を追加します
       className={styles.section}
-      initial={{ opacity: 0, y: 50 }} // 初期状態：透明で、少し下にある
-      whileInView={{ opacity: 1, y: 0 }} // 画面内に入ったら：不透明になり、元の位置に戻る
-      viewport={{ once: true, amount: 0.3 }} // アニメーションを1回だけ再生、要素が30%見えたら開始
-      transition={{ duration: 0.8, ease: "easeOut" }} // 0.8秒かけてアニメーション
+      initial={{ opacity: 0, y: 50 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.3 }}
+      transition={{ duration: 0.8, ease: "easeOut" }}
     >
       <div className={styles.container}>
         <div className={styles.imageWrapper}>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -16,15 +16,18 @@ const Header = () => {
     <header className={styles.header}>
       <div className={styles.container}>
         <div className={styles.logo}>
-          <Link href="/">My Portfolio</Link>
+          {/* ↓↓↓ Homeへのリンクもアンカーリンクに変更 ↓↓↓ */}
+          <Link href="/#home">My Portfolio</Link>
         </div>
 
         {/* PC用ナビゲーション */}
         <nav className={`${styles.nav} ${styles.pcNav}`}>
           <ul>
-            <li><Link href="/">Home</Link></li>
-            <li><Link href="/works">Works</Link></li>
-            <li><Link href="/contact">Contact</Link></li>
+            {/* ↓↓↓ ここのリンクをすべて変更します ↓↓↓ */}
+            <li><Link href="/#home">Home</Link></li>
+            <li><Link href="/#about">About</Link></li>
+            <li><Link href="/#works">Works</Link></li>
+            <li><Link href="/#contact">Contact</Link></li>
           </ul>
         </nav>
 
@@ -44,9 +47,11 @@ const Header = () => {
       <div className={`${styles.mobileMenu} ${isOpen ? styles.open : ''}`}>
         <nav>
           <ul>
-            <li><Link href="/" onClick={toggleMenu}>Home</Link></li>
-            <li><Link href="/works" onClick={toggleMenu}>Works</Link></li>
-            <li><Link href="/contact" onClick={toggleMenu}>Contact</Link></li>
+            {/* ↓↓↓ ここのリンクもすべて変更します ↓↓↓ */}
+            <li><Link href="/#home" onClick={toggleMenu}>Home</Link></li>
+            <li><Link href="/#about" onClick={toggleMenu}>About</Link></li>
+            <li><Link href="/#works" onClick={toggleMenu}>Works</Link></li>
+            <li><Link href="/#contact" onClick={toggleMenu}>Contact</Link></li>
           </ul>
         </nav>
       </div>

--- a/src/components/Works.tsx
+++ b/src/components/Works.tsx
@@ -22,18 +22,16 @@ const dummyWorks = [
   },
 ];
 
-// 親要素(コンテナ)用のアニメーション設定
 const containerVariants = {
   hidden: { opacity: 0 },
   visible: {
     opacity: 1,
     transition: {
-      staggerChildren: 0.2, // 子要素を0.2秒ずつずらして表示
+      staggerChildren: 0.2,
     },
   },
 };
 
-// 子要素(カード)用のアニメーション設定
 const cardVariants = {
   hidden: { y: 50, opacity: 0 },
   visible: { y: 0, opacity: 1 },
@@ -42,8 +40,8 @@ const cardVariants = {
 
 const Works = () => {
   return (
-    // セクション全体をアニメーションのトリガーにする
     <motion.section 
+      id="works" // ← この行を追加します
       className={styles.section}
       variants={containerVariants}
       initial="hidden"
@@ -53,13 +51,12 @@ const Works = () => {
       <h2 className={styles.heading}>Works</h2>
       <div className={styles.gridContainer}>
         {dummyWorks.map((work) => (
-          // 各カードにもアニメーション設定を適用
           <motion.div 
             key={work.id} 
             className={styles.card}
             variants={cardVariants}
-            whileHover={{ y: -10, scale: 1.03 }} // ホバー時のアニメーション
-            transition={{ type: "spring", stiffness: 300 }} // バネのような動き
+            whileHover={{ y: -10, scale: 1.03 }}
+            transition={{ type: "spring", stiffness: 300 }}
           >
             <div className={styles.thumbnailPlaceholder} />
             <div className={styles.cardContent}>


### PR DESCRIPTION
## 概要
ヘッダーのナビゲーションリンクをクリックした際に、別ページに遷移するのではなく、ページ内の該当セクションへスムーズにスクロールするように機能を変更しました。これにより、シングルページアプリケーションとしてのUXが向上します。

## 実装内容
- 各主要セクション (`Home`, `About`, `Works`) に `id` 属性を追加しました。
- `Header` コンポーネント内の `Link` タグの `href` を、アンカーリンク (`/#...`) 形式に修正しました。
- `globals.css` に `scroll-behavior: smooth;` を追加し、ブラウザのネイティブ機能でスムーズスクロールを実現しました。

## 関連Issue
Closes #13
(※ `Issues`タブで確認した、今回の正しいIssue番号に修正してください)