### PR TITLE
style: ヘッダーのコンテナ幅を広げレイアウトを調整

### DIFF
--- a/src/components/Header.module.css
+++ b/src/components/Header.module.css
@@ -13,7 +13,7 @@
 }
 
 .container {
-  max-width: 1024px;
+  max-width: 1350px;
   margin: 0 auto;
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## 概要
ヘッダーのレイアウトを微調整し、サイトロゴがもう少し左側に表示されるようにしました。

## 変更内容
- `Header.module.css` の `.container` の `max-width` を `1024px` から `1152px` に変更しました。

## 関連Issue
Closes #15